### PR TITLE
feature: update sponsors section text

### DIFF
--- a/css/default.css
+++ b/css/default.css
@@ -190,6 +190,10 @@ footer .row {
   padding: 24px 24px 0px 24px;
 }
 
+p.footnote {
+  font-size: 0.9em;
+}
+
 #topics h4 {
   padding-top: 0;
   margin-top: 0;

--- a/index.html
+++ b/index.html
@@ -263,7 +263,12 @@
   </div>
 
   <div class="col s12 m12">
-    If you want to become a sponsor simply <a href="#registration">book a sponsor ticket</a>.
+    <p>
+      We thank the following organizations for their generous sponsorship*, which made NixCon 2019 possible:
+    </p>
+    <p class="footnote">
+      * If you want to become a sponsor simply <a href="#registration">book a sponsor ticket</a>.
+    </p>
   </div>
 
   <div class="row nixos-sponsor">


### PR DESCRIPTION
Properly thank the sponsors before listing them. It's the polite thing to do.

Move the previous message inviting for sponsorship to a footnote right after
the intro sentence. It does not belong to the main message of the section,
hence the smaller text and footnote status, but is still quite visible where it
matters.